### PR TITLE
fix: loading glb files

### DIFF
--- a/packages/webgl-components/src/loading/asset-loader.ts
+++ b/packages/webgl-components/src/loading/asset-loader.ts
@@ -14,6 +14,7 @@ import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader';
 export default class AssetLoader extends ParallelLoader {
   dracoLoader?: DRACOLoader;
   ktx2Loader?: KTX2Loader;
+  meshoptDecoder: any;
   // workerLoader!: WorkerLoader;
 
   constructor(settings: LoaderSettings, manager: LoaderManager = new LoaderManager('asset-loader')) {
@@ -37,6 +38,10 @@ export default class AssetLoader extends ParallelLoader {
   setKtx2Loader(ktx2Loader: KTX2Loader) {
     this.ktx2Loader = ktx2Loader;
   }
+  setMeshoptDecoder(decoder: any) {
+    console.log(decoder);
+    this.meshoptDecoder = decoder;
+  }
 
   createLoaders(manifest: Asset[]) {
     manifest.forEach((asset) => {
@@ -57,8 +62,12 @@ export default class AssetLoader extends ParallelLoader {
   }
 
   nextInQueue(loader: Loader) {
-    if (loader instanceof ThreeGLTFLoader && this.dracoLoader) {
-      loader.setDracoLoader(this.dracoLoader);
+    if (loader instanceof ThreeGLTFLoader) {
+      if (this.dracoLoader) loader.setDracoLoader(this.dracoLoader);
+
+      if (this.ktx2Loader) loader.setKtx2Loader(this.ktx2Loader);
+
+      if (this.meshoptDecoder) loader.setMeshoptDecoder(this.meshoptDecoder);
     }
     if (loader instanceof ThreeKtx2TexureLoader && this.ktx2Loader) {
       loader.setKtx2Loader(this.ktx2Loader);

--- a/packages/webgl-components/src/loading/asset-loading.stories.ts
+++ b/packages/webgl-components/src/loading/asset-loading.stories.ts
@@ -20,6 +20,9 @@ import RenderStats, { RenderStatsPosition } from '../utils/stats';
 import AssetLoader from './asset-loader';
 import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader';
 
+/* eslint @typescript-eslint/no-var-requires: "off" */
+const { MeshoptDecoder } = require('three/examples/jsm/libs/meshopt_decoder.module.js');
+
 export default { title: 'Loader' };
 
 export const allAssetTypes = () => {
@@ -48,7 +51,7 @@ export const allAssetTypes = () => {
     }),
     new Asset({
       id: 'jam3-logo',
-      src: '/assets/jam3-high.glb',
+      src: '/assets/jam3.glb',
       type: AssetType.GLTF
     }),
     new Asset({
@@ -81,6 +84,7 @@ export const allAssetTypes = () => {
   const loader = new AssetLoader({ id: 'example', parallelLoads: 5, preferWebWorker: true });
   loader.setDracoLoader(dracoLoader);
   loader.setKtx2Loader(ktxLoader);
+  loader.setMeshoptDecoder(MeshoptDecoder);
 
   loader.manager.on('progress', (progress: number) => {
     console.log('progress', progress);

--- a/packages/webgl-components/src/loading/three-gltf-loader.ts
+++ b/packages/webgl-components/src/loading/three-gltf-loader.ts
@@ -2,7 +2,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader';
 import Loader, { LoaderSettings } from './loader';
 import LoaderManager from './loader-manager';
-
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader';
 /**
  * Threejs GLTF Loader
  *
@@ -12,10 +12,21 @@ import LoaderManager from './loader-manager';
  */
 export default class ThreeGLTFLoader extends Loader {
   dracoLoader?: DRACOLoader;
+  ktx2Loader?: KTX2Loader;
+  meshoptDecoder?: any;
 
   setDracoLoader(dracoLoader: DRACOLoader) {
     this.dracoLoader = dracoLoader;
   }
+
+  setKtx2Loader(ktx2Loader: KTX2Loader) {
+    this.ktx2Loader = ktx2Loader;
+  }
+
+  setMeshoptDecoder(decoder: any) {
+    this.meshoptDecoder = decoder;
+  }
+
   load = (settings?: LoaderSettings, manager: LoaderManager = new LoaderManager('three-gltf-loader')) => {
     if (settings) {
       this.settings = Object.assign(this.settings, settings);
@@ -27,6 +38,15 @@ export default class ThreeGLTFLoader extends Loader {
 
     if (this.dracoLoader != null) {
       loader.setDRACOLoader(this.dracoLoader);
+    }
+
+    if (this.ktx2Loader != null) {
+      loader.setKTX2Loader(this.ktx2Loader);
+    }
+
+    if (this.meshoptDecoder != null) {
+      console.log(this.meshoptDecoder);
+      loader.setMeshoptDecoder(this.meshoptDecoder);
     }
 
     const onLoaded = (gltf: unknown) => {


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

fixes the gltf + ktx combo.

set the `meshoptDecoder` with the type `any` since the original module declaration declares a variable and not a type. same thing with the `require('...')` 
