### PR TITLE
Add unexposed ThreeSoundLoader, gui.enable() & gui.disable()

### DIFF
--- a/packages/webgl-components/package.json
+++ b/packages/webgl-components/package.json
@@ -7,7 +7,7 @@
     "components",
     "best practices"
   ],
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "author": {
     "name": "Amelie Maia",

--- a/packages/webgl-components/src/loading/index.ts
+++ b/packages/webgl-components/src/loading/index.ts
@@ -7,6 +7,7 @@ import JSONLoader from './json-loader';
 import ThreeFBXLoader from './three-fbx-loader';
 import ThreeGLTFLoader from './three-gltf-loader';
 import ThreeTextureLoader from './three-texture-loader';
+import ThreeSoundLoader from './three-sound-loader';
 
 export {
   Loader,
@@ -18,5 +19,6 @@ export {
   JSONLoader,
   ThreeFBXLoader,
   ThreeGLTFLoader,
-  ThreeTextureLoader
+  ThreeTextureLoader,
+  ThreeSoundLoader
 };

--- a/packages/webgl-components/src/utils/gui.ts
+++ b/packages/webgl-components/src/utils/gui.ts
@@ -9,6 +9,7 @@ export class GUIWrapper {
   controllers: Array<unknown> = [];
   folders: Array<unknown> = [];
   _closed = false;
+  _disabled = false;
   _hidden = false;
   _title = '';
   domElement!: HTMLElement;
@@ -38,6 +39,12 @@ export class GUIWrapper {
     return this;
   }
   title(_arg0?: unknown) {
+    return this;
+  }
+  enable(_arg0?: unknown) {
+    return this;
+  }
+  disable(_arg0?: unknown) {
     return this;
   }
   show(_arg0?: unknown) {


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

- `ThreeSoundLoader` wasn't exposed
- `GUIWrapper` had missing functions `enable()` & `disable()` as long as `_disabled` which are included into `lil-gui@0.16.1`.

## Solution Description

- Added those 

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [x] N/A

**Aditional comments:**
